### PR TITLE
removed tweets from GoC users, too cluttered

### DIFF
--- a/dashboards/cspsmashing.erb
+++ b/dashboards/cspsmashing.erb
@@ -2,44 +2,37 @@
 
 <script type='text/javascript'>
 $(function() {
-  Dashing.widget_base_dimensions = [469, 130]
-  Dashing.numColumns = 4
+  Dashing.widget_base_dimensions = [580, 120]
+  Dashing.numColumns = 3
 });
 </script>
 
 <div class="gridster">
   <ul>
-    <li data-row="1" data-col="1" data-sizex="1" data-sizey="6">
-      <div data-id="twitter_user_terms" data-view="Comments" style="background-color:#00afd7;" data-moreinfo="Tweets @sourceclear" ></div>
-      <i class="icon-twitter icon-background"></i>
-    </li>
-    <li data-row="7" data-col="1" data-sizex="1" data-sizey="2">
-      <div data-id="twitter_users_title" data-view="Text" data-title="GC Twitter Users" data-text="What is being said by GC Twitter Users." data-moreinfo="From: wiki.gccollab.ca/GC_Twitter_Community"></div>
+
+    <li data-row="1" data-col="1" data-sizex="1" data-sizey="2">
+      <div data-id="twitter_hashtags_title" data-view="Text" style="background-color:#794bc4;" data-title="GoC Twitter Hashtags" data-text="Recent Tweets for Government of Canada Topics" data-moreinfo=""></div>
     </li>
 
-    <li data-row="1" data-col="2" data-sizex="1" data-sizey="2">
-      <div data-id="twitter_hashtags_title" data-view="Text" data-title="GC Twitter Hashtags" data-text="What is being said at GC Twitter Hashtags." data-moreinfo=""></div>
-    </li>
-
-    <li data-row="3" data-col="2" data-sizex="1" data-sizey="6">
+    <li data-row="3" data-col="1" data-sizex="1" data-sizey="6">
       <div data-id="twitter_hashtag_terms" data-view="Comments" style="background-color:#00afd7;" data-moreinfo="Tweets @sourceclear" ></div>
       <i class="icon-twitter icon-background"></i>
     </li>
     
-    <li data-row="1" data-col="3" data-sizex="1" data-sizey="4">
+    <li data-row="1" data-col="2" data-sizex="1" data-sizey="4">
       <div data-view="TwelveHourClock"></div>
     </li>
     
-    <li data-row="5" data-col="3" data-sizex="1" data-sizey="4">
+    <li data-row="5" data-col="2" data-sizex="1" data-sizey="4">
       <div data-id="forecast" data-view="Forecast" data-title="Ottawa Weather Forecast" ></div>
     </li>
 
-    <li data-row="1" data-col="4" data-sizex="1" data-sizey="4">
+    <li data-row="1" data-col="3" data-sizex="1" data-sizey="4">
       <div data-id="twitter_digiacad_en" data-view="Comments" style="background-color:#00afd7;" data-moreinfo="Tweets @sourceclear" ></div>
       <i class="icon-twitter icon-background"></i>
     </li>
 
-    <li data-row="5" data-col="4" data-sizex="1" data-sizey="4">
+    <li data-row="5" data-col="3" data-sizex="1" data-sizey="4">
       <div data-id="twitter_digiacad_fr" data-view="Comments" style="background-color:#00afd7;" data-moreinfo="Tweets @sourceclear" ></div>
       <i class="icon-twitter icon-background"></i>
     </li>

--- a/jobs/twitter.rb
+++ b/jobs/twitter.rb
@@ -97,6 +97,10 @@ SCHEDULER.every "5m", :first_in => 0 do |job|
     end
     ###### End retreiving hashtags ######
 
+    # COMMENTED OUT - IF not readded by April 2020 delete the following multine comment block (=begin retreiving user tweets to =end)
+    # Removed the user's tweets on the dashboard, so this block and the file /jobs/user_search_terms.json is not needed
+    # Matthew Clements, March 4 2020
+=begin
     ###### Begin retreiving user tweets ######
     # initial attempt at retreiving tweets
     tweets_users = twitter.search(get_search_string("user_search_terms"), options={tweet_mode: "extended"}).take(50)
@@ -122,9 +126,7 @@ SCHEDULER.every "5m", :first_in => 0 do |job|
       print "\e[33mNo Tweets Found by the Twitter Widget. Ensure your search term in twitter.rb is correct.\e[0m"
     end
     ###### End retreiving user tweets ######
-
-    #DigiAcademyCAN
-    #AcademieNumCAN
+=end
 
     ###### Begin retreiving DigiAcademyCAN and AcademieNumCAN tweets ######
     # initial attempt at retreiving tweets


### PR DESCRIPTION
Removed the column that listed tweets from random GoC Twitter users
Commented out the block of code that queried the Twitter API for that column, if the change is permanent after design review (and _clear_ instructions on removing the commented code)
Resized the dashboard